### PR TITLE
process data creat 3 csv files and pdf for each video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 images/
 media/
 videos/
+
+# Ignore Files
+*.pdf 

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ videos/
 
 # Ignore Files
 *.pdf 
+*.csv

--- a/src/generator.py
+++ b/src/generator.py
@@ -76,8 +76,7 @@ def video_file_generator(root_dir, metadata_csv):
         for dirpath, _, filenames in os.walk(root_dir):
             # Filter video files once, early
             video_files = [
-                os.path.join(dirpath, f) for f in filenames
-                if os.path.splitext(f)[1].lower() in video_extensions
+                os.path.join(dirpath, f) for f in filenames if os.path.splitext(f)[1].lower() in video_extensions
             ]
 
             for video_path in video_files:

--- a/src/main.py
+++ b/src/main.py
@@ -47,6 +47,12 @@ def main():
         video_path = args.video_path
         print(f"Processing video for visualization and data collection: {video_path}")
 
+        # Extract video name for PDF naming
+        video_name = os.path.basename(video_path).split('.')[0]
+        pdf_folder = "PDF"
+        os.makedirs(pdf_folder, exist_ok=True)
+        pdf_path = os.path.join(pdf_folder, f"{video_name}.pdf")
+
         # Process the specified video for visualization and data collection
         result = process_video(video_path, display_video=True)
         if not result:
@@ -56,8 +62,8 @@ def main():
         # Unpack results
         metadata, joints_data, smoothed_data, peaks_data, step_counts_joint = result
 
-        # Visualize the joint motion using the precomputed data
-        visualize_data(joints_data, smoothed_data, peaks_data)
+        # Visualize the joint motion using the precomputed data and save to PDF
+        visualize_data(joints_data, smoothed_data, peaks_data, output_path=pdf_path)
     else:
         print("Unsupported action.")
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,93 +7,88 @@ from video_processing import process_video, visualize_data, save_step_data_to_cs
 
 def process_and_visualize_video(video_path, output_root, metadata_csv, annotation_file=None):
     """
-    Processes a single video, saves metadata, and generates results (PDF, CSVs) in a dedicated folder.
+    Verarbeitet ein einzelnes Video, speichert Metadaten und Ergebnisse (PDF, CSV) in einem benannten Ordner.
 
     Parameters:
-        video_path (str): Path to the video file.
-        output_root (str): Root directory where the video folder will be created.
-        metadata_csv (str): Path to the central metadata CSV file.
-        annotation_file (str): Path to the Excel file with manual annotations (optional).
+        video_path (str): Pfad zum Video.
+        output_root (str): Root-Verzeichnis, in dem der Videoordner erstellt wird.
+        metadata_csv (str): Pfad zur zentralen Metadatendatei.
+        annotation_file (str): Pfad zur Excel-Datei mit manuellen Annotationen (optional).
     """
     video_name = os.path.splitext(os.path.basename(video_path))[0]
     video_folder = os.path.join(output_root, video_name)
     os.makedirs(video_folder, exist_ok=True)
 
-    print(f"Processing video: {video_path}")
+    print(f"Verarbeite Video: {video_path}")
 
-    # Save metadata
+    # Speichern der Metadaten
     save_metadata(video_path, metadata_csv, annotation_file if annotation_file else None)
 
-    # Process and visualize video
+    # Verarbeitung und Visualisierung
     result = process_video(video_path, display_video=False)
     if not result:
-        print(f"Failed to process {video_path}")
+        print(f"Fehler beim Verarbeiten von {video_path}")
         return
 
-    # Unpack results
+    # Ergebnisse entpacken
     metadata, joints_data, smoothed_data, peaks_data, step_counts_joint = result
 
-    # Create and save the PDF
+    # PDF erstellen und speichern
     pdf_path = os.path.join(video_folder, f"{video_name}.pdf")
     visualize_data(joints_data, smoothed_data, peaks_data, output_path=pdf_path)
 
-    # Save CSV files
+    # CSV-Dateien speichern
     save_step_data_to_csv(video_folder, joints_data, smoothed_data, peaks_data, step_counts_joint)
 
-    print(f"Processing complete. Results saved in folder: {video_folder}")
+    print(f"Verarbeitung abgeschlossen. Ergebnisse im Ordner: {video_folder}")
 
 
 def process_all_videos_in_directory(root_dir, output_root, annotation_file=None):
     """
-    Scans a directory for videos and processes all unprocessed ones.
-    Saves metadata and results for each video.
+    Durchsucht ein Verzeichnis nach Videos und verarbeitet alle, die noch nicht verarbeitet wurden.
+    Speichert Metadaten und Ergebnisse.
 
     Parameters:
-        root_dir (str): Directory containing videos.
-        output_root (str): Target directory for all results.
-        annotation_file (str): Path to the Excel file with manual annotations (optional).
+        root_dir (str): Verzeichnis mit Videos.
+        output_root (str): Zielverzeichnis für alle Ergebnisse.
+        annotation_file (str): Pfad zur Excel-Datei mit manuellen Annotationen (optional).
     """
     metadata_csv = os.path.join(output_root, "metadata.csv")
     for video_path in video_file_generator(root_dir, metadata_csv):
         process_and_visualize_video(video_path, output_root, metadata_csv, annotation_file)
-    print("All videos processed.")
+    print("Alle Videos verarbeitet.")
 
 
 def main():
     """
-    Main function for video processing.
+    Hauptfunktion für die Videoverarbeitung.
     """
     parser = argparse.ArgumentParser(description="Video Processing Script")
-    parser.add_argument(
-        "--action",
-        type=str,
-        choices=["save_metadata", "visualize_data"],
-        required=True,
-        help="Action to perform: 'save_metadata' or 'visualize_data'.",
-    )
-    parser.add_argument(
-        "--root_dir", type=str, help="Directory containing videos (required for 'save_metadata' and 'visualize_data')."
-    )
-    parser.add_argument("--video_path", type=str, help="Path to a specific video (only for 'visualize_data').")
-    parser.add_argument("--output_root", type=str, default="output", help="Root directory for output files.")
-    parser.add_argument(
-        "--annotation_file", type=str, required=False, help="Path to the Excel file with manual annotations."
-    )
+    parser.add_argument("--action", type=str, choices=["save_metadata", "visualize_data"], required=True,
+                        help="Aktion: 'save_metadata' oder 'visualize_data'.")
+    parser.add_argument("--root_dir", type=str,
+                        help="Verzeichnis mit Videos (benötigt für 'save_metadata' und 'visualize_data').")
+    parser.add_argument("--video_path", type=str,
+                        help="Pfad zu einem bestimmten Video (nur für 'visualize_data').")
+    parser.add_argument("--output_root", type=str, default="output",
+                        help="Root-Verzeichnis für die Ausgabedateien.")
+    parser.add_argument("--annotation_file", type=str, required=False,
+                        help="Pfad zur Excel-Datei mit manuellen Annotationen.")
 
     args = parser.parse_args()
 
     if args.action == "visualize_data":
         if args.video_path:
-            process_and_visualize_video(
-                args.video_path, args.output_root, os.path.join(args.output_root, "metadata.csv"), args.annotation_file
-            )
+            process_and_visualize_video(args.video_path, args.output_root, 
+                                        os.path.join(args.output_root, "metadata.csv"), 
+                                        args.annotation_file)
         elif args.root_dir:
             process_all_videos_in_directory(args.root_dir, args.output_root, args.annotation_file)
         else:
-            print("Error: Please provide either '--video_path' or '--root_dir'.")
+            print("Fehler: Bitte entweder '--video_path' oder '--root_dir' angeben.")
     elif args.action == "save_metadata":
         if not args.root_dir:
-            print("Error: '--root_dir' is required for 'save_metadata'.")
+            print("Fehler: '--root_dir' ist erforderlich für 'save_metadata'.")
             return
 
         metadata_csv = os.path.join(args.output_root, "metadata.csv")
@@ -102,7 +97,7 @@ def main():
             save_metadata(video_path, metadata_csv, annotation_file)
         print_summary()
     else:
-        print("Invalid action. Please choose 'save_metadata' or 'visualize_data'.")
+        print("Ungültige Aktion. Bitte 'save_metadata' oder 'visualize_data' wählen.")
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -2,70 +2,103 @@ import argparse
 import os
 from metadata_handler import save_metadata, print_summary
 from generator import video_file_generator
-from video_processing import process_video, visualize_data
+from video_processing import process_video, visualize_data, save_step_data_to_csv
+
+
+def process_and_visualize_video(video_path, output_root, metadata_csv, annotation_file=None):
+    """
+    Verarbeitet ein einzelnes Video, speichert Metadaten und Ergebnisse (PDF, CSV) in einem benannten Ordner.
+
+    Parameters:
+        video_path (str): Pfad zum Video.
+        output_root (str): Root-Verzeichnis, in dem der Videoordner erstellt wird.
+        metadata_csv (str): Pfad zur zentralen Metadatendatei.
+        annotation_file (str): Pfad zur Excel-Datei mit manuellen Annotationen (optional).
+    """
+    video_name = os.path.splitext(os.path.basename(video_path))[0]
+    video_folder = os.path.join(output_root, video_name)
+    os.makedirs(video_folder, exist_ok=True)
+
+    print(f"Verarbeite Video: {video_path}")
+
+    # Speichern der Metadaten
+    save_metadata(video_path, metadata_csv, annotation_file if annotation_file else None)
+
+    # Verarbeitung und Visualisierung
+    result = process_video(video_path, display_video=False)
+    if not result:
+        print(f"Fehler beim Verarbeiten von {video_path}")
+        return
+
+    # Ergebnisse entpacken
+    metadata, joints_data, smoothed_data, peaks_data, step_counts_joint = result
+
+    # PDF erstellen und speichern
+    pdf_path = os.path.join(video_folder, f"{video_name}.pdf")
+    visualize_data(joints_data, smoothed_data, peaks_data, output_path=pdf_path)
+
+    # CSV-Dateien speichern
+    save_step_data_to_csv(video_folder, joints_data, smoothed_data, peaks_data, step_counts_joint)
+
+    print(f"Verarbeitung abgeschlossen. Ergebnisse im Ordner: {video_folder}")
+
+
+def process_all_videos_in_directory(root_dir, output_root, annotation_file=None):
+    """
+    Durchsucht ein Verzeichnis nach Videos und verarbeitet alle, die noch nicht verarbeitet wurden.
+    Speichert Metadaten und Ergebnisse.
+
+    Parameters:
+        root_dir (str): Verzeichnis mit Videos.
+        output_root (str): Zielverzeichnis für alle Ergebnisse.
+        annotation_file (str): Pfad zur Excel-Datei mit manuellen Annotationen (optional).
+    """
+    metadata_csv = os.path.join(output_root, "metadata.csv")
+    for video_path in video_file_generator(root_dir, metadata_csv):
+        process_and_visualize_video(video_path, output_root, metadata_csv, annotation_file)
+    print("Alle Videos verarbeitet.")
+
 
 def main():
     """
-    Main function to process videos and perform actions based on command-line arguments.
+    Hauptfunktion für die Videoverarbeitung.
     """
     parser = argparse.ArgumentParser(description="Video Processing Script")
     parser.add_argument("--action", type=str, choices=["save_metadata", "visualize_data"], required=True,
-                        help="Action to perform: 'save_metadata' or 'visualize_data'.")
+                        help="Aktion: 'save_metadata' oder 'visualize_data'.")
     parser.add_argument("--root_dir", type=str,
-                        help="Path to the root directory containing videos (required for 'save_metadata').")
+                        help="Verzeichnis mit Videos (benötigt für 'save_metadata' und 'visualize_data').")
     parser.add_argument("--video_path", type=str,
-                        help="Path to a specific video file (required for 'visualize_data').")
+                        help="Pfad zu einem bestimmten Video (nur für 'visualize_data').")
+    parser.add_argument("--output_root", type=str, default="output",
+                        help="Root-Verzeichnis für die Ausgabedateien.")
     parser.add_argument("--annotation_file", type=str, required=False,
-                        help="Path to the Excel file containing manual step annotations (optional).")
+                        help="Pfad zur Excel-Datei mit manuellen Annotationen.")
 
     args = parser.parse_args()
 
-    if args.action == "save_metadata":
+    if args.action == "visualize_data":
+        if args.video_path:
+            process_and_visualize_video(args.video_path, args.output_root, 
+                                        os.path.join(args.output_root, "metadata.csv"), 
+                                        args.annotation_file)
+        elif args.root_dir:
+            process_all_videos_in_directory(args.root_dir, args.output_root, args.annotation_file)
+        else:
+            print("Fehler: Bitte entweder '--video_path' oder '--root_dir' angeben.")
+    elif args.action == "save_metadata":
         if not args.root_dir:
-            print("Error: You must specify the --root_dir argument for saving metadata.")
+            print("Fehler: '--root_dir' ist erforderlich für 'save_metadata'.")
             return
 
-        # Use the root directory as annotation file path if none is provided
+        metadata_csv = os.path.join(args.output_root, "metadata.csv")
         annotation_file = args.annotation_file or os.path.join(args.root_dir, "step_annotations.xlsx")
-
-        # Define the central metadata.csv path
-        metadata_csv = os.path.join(args.root_dir, "metadata.csv")
-
-        # Process new videos
         for video_path in video_file_generator(args.root_dir, metadata_csv):
-            print(f"Processing: {video_path}")
             save_metadata(video_path, metadata_csv, annotation_file)
-
-        # Print summary at the end
         print_summary()
-
-    elif args.action == "visualize_data":
-        if not args.video_path:
-            print("Error: You must specify the --video_path argument for visualizing data.")
-            return
-
-        video_path = args.video_path
-        print(f"Processing video for visualization and data collection: {video_path}")
-
-        # Extract video name for PDF naming
-        video_name = os.path.basename(video_path).split('.')[0]
-        pdf_folder = "PDF"
-        os.makedirs(pdf_folder, exist_ok=True)
-        pdf_path = os.path.join(pdf_folder, f"{video_name}.pdf")
-
-        # Process the specified video for visualization and data collection
-        result = process_video(video_path, display_video=True)
-        if not result:
-            print(f"Failed to process video '{video_path}'.")
-            return
-
-        # Unpack results
-        metadata, joints_data, smoothed_data, peaks_data, step_counts_joint = result
-
-        # Visualize the joint motion using the precomputed data and save to PDF
-        visualize_data(joints_data, smoothed_data, peaks_data, output_path=pdf_path)
     else:
-        print("Unsupported action.")
+        print("Ungültige Aktion. Bitte 'save_metadata' oder 'visualize_data' wählen.")
+
 
 if __name__ == "__main__":
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -64,12 +64,12 @@ def main():
     Hauptfunktion für die Videoverarbeitung.
     """
     parser = argparse.ArgumentParser(description="Video Processing Script")
-    parser.add_argument("--action", type=str, choices=["save_metadata", "visualize_data"], required=True,
-                        help="Aktion: 'save_metadata' oder 'visualize_data'.")
+    parser.add_argument("--action", type=str, choices=["save_metadata", "process_data"], required=True,
+                        help="Aktion: 'save_metadata' oder 'process_data'.")
     parser.add_argument("--root_dir", type=str,
-                        help="Verzeichnis mit Videos (benötigt für 'save_metadata' und 'visualize_data').")
+                        help="Verzeichnis mit Videos (benötigt für 'save_metadata' und 'process_data').")
     parser.add_argument("--video_path", type=str,
-                        help="Pfad zu einem bestimmten Video (nur für 'visualize_data').")
+                        help="Pfad zu einem bestimmten Video (nur für 'process_data').")
     parser.add_argument("--output_root", type=str, default="output",
                         help="Root-Verzeichnis für die Ausgabedateien.")
     parser.add_argument("--annotation_file", type=str, required=False,
@@ -77,7 +77,7 @@ def main():
 
     args = parser.parse_args()
 
-    if args.action == "visualize_data":
+    if args.action == "process_data":
         if args.video_path:
             process_and_visualize_video(args.video_path, args.output_root, 
                                         os.path.join(args.output_root, "metadata.csv"), 
@@ -97,7 +97,7 @@ def main():
             save_metadata(video_path, metadata_csv, annotation_file)
         print_summary()
     else:
-        print("Ungültige Aktion. Bitte 'save_metadata' oder 'visualize_data' wählen.")
+        print("Ungültige Aktion. Bitte 'save_metadata' oder 'process_data' wählen.")
 
 
 if __name__ == "__main__":

--- a/src/metadata_handler.py
+++ b/src/metadata_handler.py
@@ -6,81 +6,87 @@ from video_processing import process_video
 
 def save_metadata(video_path, metadata_csv, annotation_file=None):
     """
-    Saves metadata of a video into a CSV file and optionally checks step counts against annotations.
+    Speichert Metadaten eines Videos in einer CSV-Datei und prüft optional die Schrittzählung mit Annotationen.
 
     Parameters:
-        video_path (str): Path to the video file.
-        metadata_csv (str): Path to the central metadata CSV file.
-        annotation_file (str): Path to the Excel file with manual step annotations (optional).
+        video_path (str): Pfad zur Videodatei.
+        metadata_csv (str): Pfad zur zentralen Metadatendatei.
+        annotation_file (str): Pfad zur Excel-Datei mit manuellen Schritt-Annotationen (optional).
     """
-    # Initialize or load the summary
+    # Initialize or load summary from a global variable
     if not hasattr(save_metadata, "summary"):
         save_metadata.summary = {"matches": 0, "non_matches": [], "no_annotations": []}
 
     summary = save_metadata.summary
 
-    # Extract metadata and steps
+    # Extrahiere Metadaten und Schritte
     result = process_video(video_path, display_video=False)
     if not result:
-        print(f"Failed to extract metadata for '{video_path}'.")
+        print(f"Fehler beim Extrahieren der Metadaten für '{video_path}'.")
         return
 
-    metadata, _, _, _, _ = result  # Unpack results from process_video
+    metadata, _, _, _, _ = result  # Ergebnisse von process_video entpacken
     required_keys = ["resolution", "fps", "duration_seconds", "creation_time", "num_steps"]
     if not all(key in metadata for key in required_keys):
-        print(f"Incomplete metadata for '{video_path}'. Skipping.")
+        print(f"Unvollständige Metadaten für '{video_path}'. Überspringe.")
         return
 
+    # Extrahiere die berechneten Schritte
     calculated_steps = metadata["num_steps"]
 
-    # Check annotations if provided
+    # Prüfe, ob Annotationen existieren, falls ein Annotation-File angegeben ist
     if annotation_file:
         if not os.path.exists(annotation_file):
-            print(f"Annotation file '{annotation_file}' does not exist.")
+            print(f"Annotationsdatei '{annotation_file}' existiert nicht. Bitte erstellen Sie diese.")
             return
 
+        # Lade die Annotationen
         annotations = pd.read_excel(annotation_file)
+
+        # Basisdateiname des Videos extrahieren
         video_filename = os.path.basename(video_path)
 
+        # Prüfe, ob Annotationen für das Video existieren
         if video_filename in annotations["filename"].values:
+            # Hole die manuelle Schrittzählung
             manual_steps = annotations.loc[annotations["filename"] == video_filename, "manual_steps"].iloc[0]
+
+            # Vergleiche berechnete Schritte mit manuellen Schritten
             if calculated_steps == manual_steps:
-                print(f"Steps match for '{video_filename}' (Manual: {manual_steps}, Calculated: {calculated_steps}).")
+                print(f"Schrittzählungen stimmen überein für '{video_filename}' (Manuell: {manual_steps}, Berechnet: {calculated_steps}).")
                 summary["matches"] += 1
             else:
-                print(
-                    f"Steps DO NOT match for '{video_filename}' (Manual: {manual_steps}, Calculated: {calculated_steps})."
-                )
-                summary["non_matches"].append(
-                    {"filename": video_filename, "manual_steps": manual_steps, "calculated_steps": calculated_steps}
-                )
-                return
+                print(f"Schrittzählungen stimmen NICHT überein für '{video_filename}' (Manuell: {manual_steps}, Berechnet: {calculated_steps}). Überspringe.")
+                summary["non_matches"].append({
+                    "filename": video_filename,
+                    "manual_steps": manual_steps,
+                    "calculated_steps": calculated_steps
+                })
+                return  # Nicht speichern, wenn Schritte nicht übereinstimmen
         else:
-            print(f"No annotation found for '{video_filename}'. Using calculated steps.")
+            print(f"Keine Annotation gefunden für '{video_filename}'. Verarbeite mit berechneten Schritten.")
 
-    # Create CSV if it doesn't exist
+    # CSV-Datei erstellen, falls nicht vorhanden
     if not os.path.exists(metadata_csv):
         with open(metadata_csv, "w", newline="") as file:
             writer = csv.writer(file)
             writer.writerow(["filename", "resolution", "fps", "duration_seconds", "creation_time", "num_steps"])
 
-    # Save metadata to CSV
+    # Schreibe Metadaten in CSV
     if not is_video_in_csv(metadata_csv, os.path.basename(video_path)):
         with open(metadata_csv, "a", newline="") as file:
             writer = csv.writer(file)
-            writer.writerow(
-                [
-                    os.path.basename(video_path),
-                    metadata["resolution"],
-                    metadata["fps"],
-                    metadata["duration_seconds"],
-                    metadata["creation_time"],
-                    metadata["num_steps"],
-                ]
-            )
-        print(f"Metadata for '{video_path}' saved in '{metadata_csv}'.")
+            writer.writerow([
+                os.path.basename(video_path),
+                metadata["resolution"],
+                metadata["fps"],
+                metadata["duration_seconds"],
+                metadata["creation_time"],
+                metadata["num_steps"]
+            ])
+        print(f"Metadaten für '{video_path}' gespeichert in '{metadata_csv}'.")
     else:
-        print(f"Metadata for '{video_path}' already exists in '{metadata_csv}'. Skipping.")
+        print(f"Metadaten für '{video_path}' sind bereits in '{metadata_csv}'. Überspringe.")
 
 
 def is_video_in_csv(csv_file, video_filename):
@@ -107,7 +113,7 @@ def is_video_in_csv(csv_file, video_filename):
 
 def print_summary():
     """
-    Prints a summary of matching and non-matching annotations.
+    Prints the summary of matching and non-matching annotations.
 
     This function should be called at the end of the main processing loop.
     """
@@ -120,6 +126,4 @@ def print_summary():
     if summary["non_matches"]:
         print("\nNon-Matching Annotations:")
         for item in summary["non_matches"]:
-            print(
-                f"  - {item['filename']}: Manual Steps = {item['manual_steps']}, Calculated Steps = {item['calculated_steps']}"
-            )
+            print(f"  - {item['filename']}: Manual Steps = {item['manual_steps']}, Calculated Steps = {item['calculated_steps']}")

--- a/src/video_processing.py
+++ b/src/video_processing.py
@@ -34,26 +34,22 @@ def process_video(video_path, display_video=False):
         return None
 
     pose = mp_pose.Pose()
-    joints_data = {
-        joint: []
-        for joint in ["right_ankle", "left_ankle", "right_heel", "left_heel", "right_foot_index", "left_foot_index"]
-    }
+    joints_data = {joint: [] for joint in ["right_ankle", "left_ankle", "right_heel", "left_heel", "right_foot_index", "left_foot_index"]}
 
-    # Extract metadata
+    # Metadata placeholders
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     fps = round(cap.get(cv2.CAP_PROP_FPS))
     resolution = f"{int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))}x{int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))}"
     duration = round(frame_count / fps, 2)
     creation_time = datetime.fromtimestamp(os.path.getctime(video_path)).strftime("%Y-%m-%d %H:%M:%S")
 
-    # Process video frame by frame
+    # Progress bar for processing frames
     with tqdm(total=frame_count, desc=f"Processing {os.path.basename(video_path)}", unit="frame") as progress:
         while cap.isOpened():
             ret, frame = cap.read()
             if not ret:
                 break
 
-            # Process the frame for pose landmarks
             rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             results = pose.process(rgb_frame)
 
@@ -74,13 +70,12 @@ def process_video(video_path, display_video=False):
                     if cv2.waitKey(5) & 0xFF == ord("q"):
                         break
 
-            progress.update(1)  # Update the progress bar
+            progress.update(1)  # Update the progress bar after each frame is processed
 
     cap.release()
     if display_video:
         cv2.destroyAllWindows()
 
-    # Analyze data and detect steps
     step_counts_joint, smoothed_data, peaks_data, num_steps = count_steps(joints_data)
     metadata = {
         "resolution": resolution,
@@ -96,7 +91,7 @@ def process_video(video_path, display_video=False):
 def count_steps(joints_data):
     """
     Dynamically calculates steps from joint motion with adaptive prominence.
-
+    
     Parameters:
         joints_data (dict): Raw joint movement data.
 
@@ -124,8 +119,8 @@ def count_steps(joints_data):
         step_counts_joint[joint] = len(peaks)
 
     # Calculate total steps
-    right_steps = step_counts_joint.get("right_foot_index", 0)
-    left_steps = step_counts_joint.get("left_foot_index", 0)
+    right_steps = step_counts_joint.get("right_ankle", 0)
+    left_steps = step_counts_joint.get("left_ankle", 0)
     num_steps = right_steps + left_steps
 
     print(f"Step Counts:")
@@ -136,64 +131,109 @@ def count_steps(joints_data):
     return step_counts_joint, smoothed_data, peaks_data, num_steps
 
 
-def save_step_data_to_csv(output_folder, joints_data, smoothed_data, peaks_data, step_counts_joint):
+
+def visualize_data(joints_data, smoothed_data, peaks_data, output_path=None):
     """
-    Saves raw data, smoothed data, and step counts to separate CSV files.
-    Only uses 'left_foot_index' and 'right_foot_index' for total steps.
+    Visualizes joint motion and detected steps, using raw data, smoothed data, and peak indices.
+    Optionally saves the plots to a PDF file.
 
     Parameters:
-        output_folder (str): Target folder for CSV files.
         joints_data (dict): Raw joint movement data.
         smoothed_data (dict): Smoothed joint movement data.
-        peaks_data (dict): Detected peaks (steps) for each joint.
-        step_counts_joint (dict): Step counts for each joint.
+        peaks_data (dict): Detected step (peak) indices for each joint.
+        output_path (str): Path to save the PDF file (optional).
+    """
+    # Plot joint motion data
+    fig, axs = plt.subplots(len(joints_data), 1, figsize=(15, 20))
+    joints = list(joints_data.keys())
+    colors = ["orange", "green", "blue", "red", "purple", "brown"]
+
+    for i, joint in enumerate(joints):
+        raw_data = joints_data[joint]
+        smoothed = smoothed_data[joint]
+        peaks = peaks_data[joint]
+
+        # Plot raw and smoothed data
+        axs[i].plot(raw_data, label=f"{joint} (raw)", alpha=0.5, color=colors[i])
+        axs[i].plot(smoothed, label=f"{joint} (smoothed)", linewidth=2, color=colors[i])
+        
+        # Highlight detected steps (peaks)
+        axs[i].scatter(peaks, smoothed[peaks], color="black", label=f"Detected Steps ({len(peaks)})")
+        axs[i].legend()
+        axs[i].set_title(f"{joint} Horizontal Movement and Step Detection")
+        axs[i].set_xlabel("Frames")
+        axs[i].set_ylabel("Horizontal Position (x)")
+
+    plt.tight_layout()
+
+    # Save to PDF if output_path is provided
+    if output_path:
+        pdf_path = output_path if output_path.endswith(".pdf") else f"{output_path}.pdf"
+        plt.savefig(pdf_path)
+        print(f"Plots saved to {pdf_path}")
+    else:
+        plt.show()
+
+    plt.close(fig)
+
+def save_step_data_to_csv(output_folder, joints_data, smoothed_data, peaks_data, step_counts_joint):
+    """
+    Speichert Rohdaten, geglättete Daten und Schrittzählungen in separaten CSV-Dateien.
+    Berechnet die Gesamtanzahl der Schritte nur basierend auf 'left_foot_index' und 'right_foot_index'.
+
+    Parameters:
+        output_folder (str): Zielordner für die CSV-Dateien.
+        joints_data (dict): Rohdaten der Gelenkbewegungen.
+        smoothed_data (dict): Geglättete Daten der Gelenkbewegungen.
+        peaks_data (dict): Detektierte Peaks (Schritte) pro Gelenk.
+        step_counts_joint (dict): Zählung der Schritte für jedes Gelenk.
     """
     os.makedirs(output_folder, exist_ok=True)
 
-    # Save raw data
+    # 1. Rohdaten speichern
     raw_data_csv = os.path.join(output_folder, "raw_data.csv")
     with open(raw_data_csv, mode="w", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Frame"] + list(joints_data.keys()))  # Header
         max_frames = max(len(data) for data in joints_data.values())
         for frame in range(max_frames):
-            row = [frame] + [
-                joints_data[joint][frame] if frame < len(joints_data[joint]) else None for joint in joints_data
-            ]
+            row = [frame] + [joints_data[joint][frame] if frame < len(joints_data[joint]) else None
+                             for joint in joints_data]
             writer.writerow(row)
-    print(f"Raw data saved to: {raw_data_csv}")
+    print(f"Rohdaten gespeichert: {raw_data_csv}")
 
-    # Save smoothed data
+    # 2. Geglättete Daten speichern
     smoothed_data_csv = os.path.join(output_folder, "smoothed_data.csv")
     with open(smoothed_data_csv, mode="w", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Frame"] + list(smoothed_data.keys()))  # Header
         max_frames = max(len(data) for data in smoothed_data.values())
         for frame in range(max_frames):
-            row = [frame] + [
-                smoothed_data[joint][frame] if frame < len(smoothed_data[joint]) else None for joint in smoothed_data
-            ]
+            row = [frame] + [smoothed_data[joint][frame] if frame < len(smoothed_data[joint]) else None
+                             for joint in smoothed_data]
             writer.writerow(row)
-    print(f"Smoothed data saved to: {smoothed_data_csv}")
+    print(f"Geglättete Daten gespeichert: {smoothed_data_csv}")
 
-    # Save step counts
+    # 3. Schrittzählung speichern
     steps_csv = os.path.join(output_folder, "step_counts.csv")
     with open(steps_csv, mode="w", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Joint", "Detected Steps", "Peaks"])  # Header
 
+        # Schreibe die Schrittzählungen für alle Gelenke außer den Total Steps
         for joint, steps in step_counts_joint.items():
-            peaks = peaks_data[joint]
-            writer.writerow([joint, steps, list(peaks)])
+            if joint not in ["left_foot_index", "right_foot_index"]:  # Ignoriere diese Gelenke vorerst
+                peaks = peaks_data[joint]
+                writer.writerow([joint, steps, list(peaks)])  # Fügt die Peaks mit hinzu
 
-        # Compute total steps
+        # Berechnung der Total Steps basierend auf 'left_foot_index' und 'right_foot_index'
         left_steps = len(peaks_data.get("left_foot_index", []))
         right_steps = len(peaks_data.get("right_foot_index", []))
         total_steps = left_steps + right_steps
 
-        # Write total steps
+        # Schreibe die Einträge für 'left_foot_index', 'right_foot_index' und die Total Steps
         writer.writerow(["left_foot_index", left_steps, list(peaks_data.get("left_foot_index", []))])
         writer.writerow(["right_foot_index", right_steps, list(peaks_data.get("right_foot_index", []))])
         writer.writerow(["Total", total_steps, ""])
 
-    print(f"Step counts saved to: {steps_csv}")
+    print(f"Schrittzählungen gespeichert: {steps_csv}")

--- a/src/video_processing.py
+++ b/src/video_processing.py
@@ -34,22 +34,26 @@ def process_video(video_path, display_video=False):
         return None
 
     pose = mp_pose.Pose()
-    joints_data = {joint: [] for joint in ["right_ankle", "left_ankle", "right_heel", "left_heel", "right_foot_index", "left_foot_index"]}
+    joints_data = {
+        joint: []
+        for joint in ["right_ankle", "left_ankle", "right_heel", "left_heel", "right_foot_index", "left_foot_index"]
+    }
 
-    # Metadata placeholders
+    # Extract metadata
     frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     fps = round(cap.get(cv2.CAP_PROP_FPS))
     resolution = f"{int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))}x{int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))}"
     duration = round(frame_count / fps, 2)
     creation_time = datetime.fromtimestamp(os.path.getctime(video_path)).strftime("%Y-%m-%d %H:%M:%S")
 
-    # Progress bar for processing frames
+    # Process video frame by frame
     with tqdm(total=frame_count, desc=f"Processing {os.path.basename(video_path)}", unit="frame") as progress:
         while cap.isOpened():
             ret, frame = cap.read()
             if not ret:
                 break
 
+            # Process the frame for pose landmarks
             rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             results = pose.process(rgb_frame)
 
@@ -70,12 +74,13 @@ def process_video(video_path, display_video=False):
                     if cv2.waitKey(5) & 0xFF == ord("q"):
                         break
 
-            progress.update(1)  # Update the progress bar after each frame is processed
+            progress.update(1)  # Update the progress bar
 
     cap.release()
     if display_video:
         cv2.destroyAllWindows()
 
+    # Analyze data and detect steps
     step_counts_joint, smoothed_data, peaks_data, num_steps = count_steps(joints_data)
     metadata = {
         "resolution": resolution,
@@ -91,7 +96,7 @@ def process_video(video_path, display_video=False):
 def count_steps(joints_data):
     """
     Dynamically calculates steps from joint motion with adaptive prominence.
-    
+
     Parameters:
         joints_data (dict): Raw joint movement data.
 
@@ -119,8 +124,8 @@ def count_steps(joints_data):
         step_counts_joint[joint] = len(peaks)
 
     # Calculate total steps
-    right_steps = step_counts_joint.get("right_ankle", 0)
-    left_steps = step_counts_joint.get("left_ankle", 0)
+    right_steps = step_counts_joint.get("right_foot_index", 0)
+    left_steps = step_counts_joint.get("left_foot_index", 0)
     num_steps = right_steps + left_steps
 
     print(f"Step Counts:")
@@ -131,111 +136,64 @@ def count_steps(joints_data):
     return step_counts_joint, smoothed_data, peaks_data, num_steps
 
 
-
-def visualize_data(joints_data, smoothed_data, peaks_data, output_path=None):
-    """
-    Visualizes joint motion and detected steps, using raw data, smoothed data, and peak indices.
-    Optionally saves the plots to a PDF file.
-
-    Parameters:
-        joints_data (dict): Raw joint movement data.
-        smoothed_data (dict): Smoothed joint movement data.
-        peaks_data (dict): Detected step (peak) indices for each joint.
-        output_path (str): Path to save the PDF file (optional).
-    """
-    # Plot joint motion data
-    fig, axs = plt.subplots(len(joints_data), 1, figsize=(15, 20))
-    joints = list(joints_data.keys())
-    colors = ["orange", "green", "blue", "red", "purple", "brown"]
-
-    for i, joint in enumerate(joints):
-        raw_data = joints_data[joint]
-        smoothed = smoothed_data[joint]
-        peaks = peaks_data[joint]
-
-        # Plot raw and smoothed data
-        axs[i].plot(raw_data, label=f"{joint} (raw)", alpha=0.5, color=colors[i])
-        axs[i].plot(smoothed, label=f"{joint} (smoothed)", linewidth=2, color=colors[i])
-        
-        # Highlight detected steps (peaks)
-        axs[i].scatter(peaks, smoothed[peaks], color="black", label=f"Detected Steps ({len(peaks)})")
-        axs[i].legend()
-        axs[i].set_title(f"{joint} Horizontal Movement and Step Detection")
-        axs[i].set_xlabel("Frames")
-        axs[i].set_ylabel("Horizontal Position (x)")
-
-    plt.tight_layout()
-
-    # Save to PDF if output_path is provided
-    if output_path:
-        pdf_path = output_path if output_path.endswith(".pdf") else f"{output_path}.pdf"
-        plt.savefig(pdf_path)
-        print(f"Plots saved to {pdf_path}")
-    else:
-        plt.show()
-
-    plt.close(fig)
-
 def save_step_data_to_csv(output_folder, joints_data, smoothed_data, peaks_data, step_counts_joint):
     """
-    Speichert Rohdaten, geglättete Daten und Schrittzählungen in separaten CSV-Dateien.
-    Berechnet die Gesamtanzahl der Schritte nur basierend auf 'left_foot_index' und 'right_foot_index'.
+    Saves raw data, smoothed data, and step counts to separate CSV files.
+    Only uses 'left_foot_index' and 'right_foot_index' for total steps.
 
     Parameters:
-        output_folder (str): Zielordner für die CSV-Dateien.
-        joints_data (dict): Rohdaten der Gelenkbewegungen.
-        smoothed_data (dict): Geglättete Daten der Gelenkbewegungen.
-        peaks_data (dict): Detektierte Peaks (Schritte) pro Gelenk.
-        step_counts_joint (dict): Zählung der Schritte für jedes Gelenk.
+        output_folder (str): Target folder for CSV files.
+        joints_data (dict): Raw joint movement data.
+        smoothed_data (dict): Smoothed joint movement data.
+        peaks_data (dict): Detected peaks (steps) for each joint.
+        step_counts_joint (dict): Step counts for each joint.
     """
     os.makedirs(output_folder, exist_ok=True)
 
-    # 1. Rohdaten speichern
+    # Save raw data
     raw_data_csv = os.path.join(output_folder, "raw_data.csv")
     with open(raw_data_csv, mode="w", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Frame"] + list(joints_data.keys()))  # Header
         max_frames = max(len(data) for data in joints_data.values())
         for frame in range(max_frames):
-            row = [frame] + [joints_data[joint][frame] if frame < len(joints_data[joint]) else None
-                             for joint in joints_data]
+            row = [frame] + [
+                joints_data[joint][frame] if frame < len(joints_data[joint]) else None for joint in joints_data
+            ]
             writer.writerow(row)
-    print(f"Rohdaten gespeichert: {raw_data_csv}")
+    print(f"Raw data saved to: {raw_data_csv}")
 
-    # 2. Geglättete Daten speichern
+    # Save smoothed data
     smoothed_data_csv = os.path.join(output_folder, "smoothed_data.csv")
     with open(smoothed_data_csv, mode="w", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Frame"] + list(smoothed_data.keys()))  # Header
         max_frames = max(len(data) for data in smoothed_data.values())
         for frame in range(max_frames):
-            row = [frame] + [smoothed_data[joint][frame] if frame < len(smoothed_data[joint]) else None
-                             for joint in smoothed_data]
+            row = [frame] + [
+                smoothed_data[joint][frame] if frame < len(smoothed_data[joint]) else None for joint in smoothed_data
+            ]
             writer.writerow(row)
-    print(f"Geglättete Daten gespeichert: {smoothed_data_csv}")
+    print(f"Smoothed data saved to: {smoothed_data_csv}")
 
-    # 3. Schrittzählung speichern
+    # Save step counts
     steps_csv = os.path.join(output_folder, "step_counts.csv")
     with open(steps_csv, mode="w", newline="") as file:
         writer = csv.writer(file)
         writer.writerow(["Joint", "Detected Steps", "Peaks"])  # Header
 
-        # Schreibe die Schrittzählungen für alle Gelenke außer den Total Steps
         for joint, steps in step_counts_joint.items():
-            if joint not in ["left_foot_index", "right_foot_index"]:  # Ignoriere diese Gelenke vorerst
-                peaks = peaks_data[joint]
-                writer.writerow([joint, steps, list(peaks)])  # Fügt die Peaks mit hinzu
+            peaks = peaks_data[joint]
+            writer.writerow([joint, steps, list(peaks)])
 
-        # Berechnung der Total Steps basierend auf 'left_foot_index' und 'right_foot_index'
+        # Compute total steps
         left_steps = len(peaks_data.get("left_foot_index", []))
         right_steps = len(peaks_data.get("right_foot_index", []))
         total_steps = left_steps + right_steps
 
-        # Schreibe die Einträge für 'left_foot_index', 'right_foot_index' und die Total Steps
+        # Write total steps
         writer.writerow(["left_foot_index", left_steps, list(peaks_data.get("left_foot_index", []))])
         writer.writerow(["right_foot_index", right_steps, list(peaks_data.get("right_foot_index", []))])
         writer.writerow(["Total", total_steps, ""])
 
-    print(f"Schrittzählungen gespeichert: {steps_csv}")
-
-
+    print(f"Step counts saved to: {steps_csv}")

--- a/src/video_processing.py
+++ b/src/video_processing.py
@@ -131,14 +131,16 @@ def count_steps(joints_data):
 
 
 
-def visualize_data(joints_data, smoothed_data, peaks_data):
+def visualize_data(joints_data, smoothed_data, peaks_data, output_path=None):
     """
     Visualizes joint motion and detected steps, using raw data, smoothed data, and peak indices.
+    Optionally saves the plots to a PDF file.
 
     Parameters:
         joints_data (dict): Raw joint movement data.
         smoothed_data (dict): Smoothed joint movement data.
         peaks_data (dict): Detected step (peak) indices for each joint.
+        output_path (str): Path to save the PDF file (optional).
     """
     # Plot joint motion data
     fig, axs = plt.subplots(len(joints_data), 1, figsize=(15, 20))
@@ -162,5 +164,15 @@ def visualize_data(joints_data, smoothed_data, peaks_data):
         axs[i].set_ylabel("Horizontal Position (x)")
 
     plt.tight_layout()
-    plt.show()
+
+    # Save to PDF if output_path is provided
+    if output_path:
+        pdf_path = output_path if output_path.endswith(".pdf") else f"{output_path}.pdf"
+        plt.savefig(pdf_path)
+        print(f"Plots saved to {pdf_path}")
+    else:
+        plt.show()
+
+    plt.close(fig)
+
 

--- a/src/video_processing.py
+++ b/src/video_processing.py
@@ -1,5 +1,6 @@
 import os
 import cv2
+import csv
 import numpy as np
 import mediapipe as mp
 from tqdm import tqdm
@@ -174,5 +175,67 @@ def visualize_data(joints_data, smoothed_data, peaks_data, output_path=None):
         plt.show()
 
     plt.close(fig)
+
+def save_step_data_to_csv(output_folder, joints_data, smoothed_data, peaks_data, step_counts_joint):
+    """
+    Speichert Rohdaten, geglättete Daten und Schrittzählungen in separaten CSV-Dateien.
+    Berechnet die Gesamtanzahl der Schritte nur basierend auf 'left_foot_index' und 'right_foot_index'.
+
+    Parameters:
+        output_folder (str): Zielordner für die CSV-Dateien.
+        joints_data (dict): Rohdaten der Gelenkbewegungen.
+        smoothed_data (dict): Geglättete Daten der Gelenkbewegungen.
+        peaks_data (dict): Detektierte Peaks (Schritte) pro Gelenk.
+        step_counts_joint (dict): Zählung der Schritte für jedes Gelenk.
+    """
+    os.makedirs(output_folder, exist_ok=True)
+
+    # 1. Rohdaten speichern
+    raw_data_csv = os.path.join(output_folder, "raw_data.csv")
+    with open(raw_data_csv, mode="w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(["Frame"] + list(joints_data.keys()))  # Header
+        max_frames = max(len(data) for data in joints_data.values())
+        for frame in range(max_frames):
+            row = [frame] + [joints_data[joint][frame] if frame < len(joints_data[joint]) else None
+                             for joint in joints_data]
+            writer.writerow(row)
+    print(f"Rohdaten gespeichert: {raw_data_csv}")
+
+    # 2. Geglättete Daten speichern
+    smoothed_data_csv = os.path.join(output_folder, "smoothed_data.csv")
+    with open(smoothed_data_csv, mode="w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(["Frame"] + list(smoothed_data.keys()))  # Header
+        max_frames = max(len(data) for data in smoothed_data.values())
+        for frame in range(max_frames):
+            row = [frame] + [smoothed_data[joint][frame] if frame < len(smoothed_data[joint]) else None
+                             for joint in smoothed_data]
+            writer.writerow(row)
+    print(f"Geglättete Daten gespeichert: {smoothed_data_csv}")
+
+    # 3. Schrittzählung speichern
+    steps_csv = os.path.join(output_folder, "step_counts.csv")
+    with open(steps_csv, mode="w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerow(["Joint", "Detected Steps", "Peaks"])  # Header
+
+        # Schreibe die Schrittzählungen für alle Gelenke außer den Total Steps
+        for joint, steps in step_counts_joint.items():
+            if joint not in ["left_foot_index", "right_foot_index"]:  # Ignoriere diese Gelenke vorerst
+                peaks = peaks_data[joint]
+                writer.writerow([joint, steps, list(peaks)])  # Fügt die Peaks mit hinzu
+
+        # Berechnung der Total Steps basierend auf 'left_foot_index' und 'right_foot_index'
+        left_steps = len(peaks_data.get("left_foot_index", []))
+        right_steps = len(peaks_data.get("right_foot_index", []))
+        total_steps = left_steps + right_steps
+
+        # Schreibe die Einträge für 'left_foot_index', 'right_foot_index' und die Total Steps
+        writer.writerow(["left_foot_index", left_steps, list(peaks_data.get("left_foot_index", []))])
+        writer.writerow(["right_foot_index", right_steps, list(peaks_data.get("right_foot_index", []))])
+        writer.writerow(["Total", total_steps, ""])
+
+    print(f"Schrittzählungen gespeichert: {steps_csv}")
 
 


### PR DESCRIPTION
Update main script to handle video processing with `process_data` action

- Renamed the action `visualize_data` to `process_data` for better clarity.
- Updated the script to process videos either individually (via `--video_path`) or in bulk (via `--root_dir`).
- Added functionality to handle both single video processing and directory-wide processing seamlessly.
- Output includes metadata, PDF visualizations, and step data in CSV format, stored in the specified `--output_root` directory.

Example usage:
To process all videos in a directory:
python src/main.py --action process_data --root_dir <D:\Step-counter\Videos\> --output_root <D:\Step-counter\Output>

To process a single video:
python src/main.py --action process_data --video_path <D:\Step-counter\Videos\video1.mp4> --output_root <D:\Step-counter\Output>